### PR TITLE
Fix file not found error in main script

### DIFF
--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -15,7 +15,9 @@ matplotlib.rcParams['axes.unicode_minus'] = False
 
 def load_raw_data():
     """Load all model data from RawData directory"""
-    with open('RawData/all_models_data.json', 'r', encoding='utf-8') as f:
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(base_dir, '../RawData/all_models_data.json')
+    with open(data_path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 def filter_models_by_nonempty(models_data, data_by_format, models, face_counts):


### PR DESCRIPTION
修复 `FileNotFoundError` 错误，通过使 `load_raw_data` 函数使用相对于脚本文件本身的路径来加载数据。