### PR TITLE
Fix file not found error in main script

### DIFF
--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -15,7 +15,11 @@ matplotlib.rcParams['axes.unicode_minus'] = False
 
 def load_raw_data():
     """Load all model data from RawData directory"""
-    with open('../RawData/all_models_data.json', 'r', encoding='utf-8') as f:
+    # 获取当前脚本所在目录
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(base_dir, '../RawData/all_models_data.json')
+    data_path = os.path.normpath(data_path)
+    with open(data_path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 def filter_models_by_nonempty(models_data, data_by_format, models, face_counts):


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `FileNotFoundError` when loading raw data by resolving the data file path relative to the script's location.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous relative path `../RawData/all_models_data.json` caused `FileNotFoundError` when `main.py` was executed from a directory other than `Scripts/`. This PR resolves the path using `os.path.abspath(__file__)` to ensure the data file is found regardless of the current working directory.