### PR TITLE
修复图表数据标签和比例显示问题

### DIFF
--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -1058,55 +1058,35 @@ def create_all_format_size_before_after(models_data):
         offset = (i - 1.5) * width * 2
         before_vals = [v if v not in [None, 0] else 0 for v in data_before[fmt]]
         after_vals = [v if v not in [None, 0] else 0 for v in data_after[fmt]]
-        texture_before = [
-            models_data[m]['formats'][fmt].get('textureSizeBeforeZipMB', 0) if fmt in models_data[m]['formats'] else 0
-            for m in models
-        ]
-        texture_after = [
-            models_data[m]['formats'][fmt].get('textureSizeAfterZipMB', 0) if fmt in models_data[m]['formats'] else 0
-            for m in models
-        ]
+        texture_before = [models_data[m]['formats'][fmt].get('textureSizeBeforeZipMB', 0) if fmt in models_data[m]['formats'] else 0 for m in models]
+        texture_after = [models_data[m]['formats'][fmt].get('textureSizeAfterZipMB', 0) if fmt in models_data[m]['formats'] else 0 for m in models]
         color_before = base_colors[i]
         color_after = tuple(np.clip(np.array(base_colors[i]) + 0.3, 0, 1))
         color_before_texture = tuple(np.clip(np.array(base_colors[i]) * 0.7, 0, 1))
         color_after_texture = tuple(np.clip(np.array(base_colors[i]) * 0.7 + 0.3, 0, 1))
         non_texture_before = [max(0, v-t) for v, t in zip(before_vals, texture_before)]
-        bars1 = ax.bar(x + offset, non_texture_before, width, label=f'{fmt} Before (Non-Texture)', color=color_before, zorder=2)
-        bars1_texture = ax.bar(x + offset, texture_before, width, bottom=non_texture_before, label=f'{fmt} Before (Texture)', color=color_before_texture, zorder=3)
+        bars1 = ax.bar(x + offset, texture_before, width, label=f'{fmt} Before (Texture)', color=color_before_texture, zorder=3)
+        bars1_nontex = ax.bar(x + offset, non_texture_before, width, bottom=texture_before, label=f'{fmt} Before (Non-Texture)', color=color_before, zorder=2)
         non_texture_after = [max(0, v-t) for v, t in zip(after_vals, texture_after)]
-        bars2 = ax.bar(x + offset + width, non_texture_after, width, label=f'{fmt} After (Non-Texture)', color=color_after, zorder=2)
-        bars2_texture = ax.bar(x + offset + width, texture_after, width, bottom=non_texture_after, label=f'{fmt} After (Texture)', color=color_after_texture, zorder=3)
+        bars2 = ax.bar(x + offset + width, texture_after, width, label=f'{fmt} After (Texture)', color=color_after_texture, zorder=3)
+        bars2_nontex = ax.bar(x + offset + width, non_texture_after, width, bottom=texture_after, label=f'{fmt} After (Non-Texture)', color=color_after, zorder=2)
         # 标注
-        for idx, (bar, v, t) in enumerate(zip(bars1, before_vals, texture_before)):
+        for idx, (bar_tex, bar_nontex, v, t) in enumerate(zip(bars2, bars2_nontex, after_vals, texture_after)):
             if v is None:
-                ax.text(bar.get_x() + bar.get_width()/2., 0.5, 'Missing', ha='center', va='bottom', fontsize=7, color='red', rotation=60, zorder=4)
+                ax.text(bar_tex.get_x() + bar_tex.get_width()/2., 0.5, 'Missing', ha='center', va='bottom', fontsize=7, color='red', rotation=60, zorder=4)
             elif v not in [None, 0]:
-                # 原有：ax.text(bar.get_x() + bar.get_width()/2., bar.get_height(), f'{v:.1f}', ...)
-                # 新增：将总值标注在柱子最顶端
-                total_height = non_texture_before[idx] + texture_before[idx]
-                ax.text(bar.get_x() + bar.get_width()/2., total_height, f'{v:.1f}', ha='center', va='bottom', fontsize=7, rotation=60, zorder=4, color='black', fontweight='bold')
+                total_height = texture_after[idx] + non_texture_after[idx]
+                # 总值标注在最顶端
+                ax.text(bar_tex.get_x() + bar_tex.get_width()/2., total_height, f'{v:.1f}', ha='center', va='bottom', fontsize=7, rotation=60, zorder=4, color='black', fontweight='bold')
                 # 纹理占比
                 if t > 0 and v > 0:
                     percent = t / v * 100
                     txt = f'{percent:.0f}%\n{t:.1f}'
-                    if t > v * 0.18:  # 足够空间
-                        ax.text(bar.get_x() + bar.get_width()/2., bar.get_y() + bar.get_height(), txt, ha='center', va='center', fontsize=7, color='white', zorder=5)
-                    else:
-                        ax.plot([bar.get_x() + bar.get_width()/2., bar.get_x() + bar.get_width()/2. + 0.05], [bar.get_y() + bar.get_height(), bar.get_y() + bar.get_height() + max(v*0.08, 2)], color='black', lw=0.7, zorder=6)
-                        ax.text(bar.get_x() + bar.get_width()/2. + 0.08, bar.get_y() + bar.get_height() + max(v*0.08, 2), txt, ha='left', va='bottom', fontsize=7, color='black', zorder=6)
-        for idx, (bar, v, t) in enumerate(zip(bars2, after_vals, texture_after)):
-            if v is None:
-                ax.text(bar.get_x() + bar.get_width()/2., 0.5, 'Missing', ha='center', va='bottom', fontsize=7, color='red', rotation=60, zorder=4)
-            elif v not in [None, 0]:
-                ax.text(bar.get_x() + bar.get_width()/2., bar.get_height(), f'{v:.1f}', ha='center', va='bottom', fontsize=7, rotation=60, zorder=4)
-                if t > 0 and v > 0:
-                    percent = t / v * 100
-                    txt = f'{percent:.0f}%\n{t:.1f}'
                     if t > v * 0.18:
-                        ax.text(bar.get_x() + bar.get_width()/2., bar.get_y() + bar.get_height(), txt, ha='center', va='center', fontsize=7, color='white', zorder=5)
+                        ax.text(bar_tex.get_x() + bar_tex.get_width()/2., bar_tex.get_y() + bar_tex.get_height(), txt, ha='center', va='center', fontsize=7, color='white', zorder=5)
                     else:
-                        ax.plot([bar.get_x() + bar.get_width()/2., bar.get_x() + bar.get_width()/2. + 0.05], [bar.get_y() + bar.get_height(), bar.get_y() + bar.get_height() + max(v*0.08, 2)], color='black', lw=0.7, zorder=6)
-                        ax.text(bar.get_x() + bar.get_width()/2. + 0.08, bar.get_y() + bar.get_height() + max(v*0.08, 2), txt, ha='left', va='bottom', fontsize=7, color='black', zorder=6)
+                        ax.plot([bar_tex.get_x() + bar_tex.get_width()/2., bar_tex.get_x() + bar_tex.get_width()/2. + 0.05], [bar_tex.get_y() + bar_tex.get_height(), bar_tex.get_y() + bar_tex.get_height() + max(v*0.08, 2)], color='black', lw=0.7, zorder=6)
+                        ax.text(bar_tex.get_x() + bar_tex.get_width()/2. + 0.08, bar_tex.get_y() + bar_tex.get_height() + max(v*0.08, 2), txt, ha='left', va='bottom', fontsize=7, color='black', zorder=6)
     all_values = []
     for fmt in formats:
         all_values += [v for v in data_before[fmt] if v not in [None, 0]]
@@ -1119,7 +1099,10 @@ def create_all_format_size_before_after(models_data):
     ax.set_xticks(x)
     labels = [get_standardized_model_name(m, f, t) for m, f, t in zip(models, face_counts, textureCounts)]
     ax.set_xticklabels(labels, rotation=45, ha='right')
-    ax.legend()
+    # 合并图例，避免重复
+    handles, labels = ax.get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    ax.legend(by_label.values(), by_label.keys())
     ax.grid(True, alpha=0.3, which='both', zorder=1)
     if use_log:
         ax.set_yscale('log')
@@ -1164,58 +1147,41 @@ def create_all_format_size_before_after_linear_tall(models_data):
         offset = (i - 1.5) * width * 2
         before_vals = [v if v not in [None, 0] else 0 for v in data_before[fmt]]
         after_vals = [v if v not in [None, 0] else 0 for v in data_after[fmt]]
-        texture_before = [
-            models_data[m]['formats'][fmt].get('textureSizeBeforeZipMB', 0) if fmt in models_data[m]['formats'] else 0
-            for m in models
-        ]
-        texture_after = [
-            models_data[m]['formats'][fmt].get('textureSizeAfterZipMB', 0) if fmt in models_data[m]['formats'] else 0
-            for m in models
-        ]
+        texture_before = [models_data[m]['formats'][fmt].get('textureSizeBeforeZipMB', 0) if fmt in models_data[m]['formats'] else 0 for m in models]
+        texture_after = [models_data[m]['formats'][fmt].get('textureSizeAfterZipMB', 0) if fmt in models_data[m]['formats'] else 0 for m in models]
         color_before = base_colors[i]
         color_after = tuple(np.clip(np.array(base_colors[i]) + 0.3, 0, 1))
         color_before_texture = tuple(np.clip(np.array(base_colors[i]) * 0.7, 0, 1))
         color_after_texture = tuple(np.clip(np.array(base_colors[i]) * 0.7 + 0.3, 0, 1))
         non_texture_before = [max(0, v-t) for v, t in zip(before_vals, texture_before)]
-        bars1 = ax.bar(x + offset, non_texture_before, width, label=f'{fmt} Before (Non-Texture)', color=color_before, zorder=2)
-        bars1_texture = ax.bar(x + offset, texture_before, width, bottom=non_texture_before, label=f'{fmt} Before (Texture)', color=color_before_texture, zorder=3)
+        bars1 = ax.bar(x + offset, texture_before, width, label=f'{fmt} Before (Texture)', color=color_before_texture, zorder=3)
+        bars1_nontex = ax.bar(x + offset, non_texture_before, width, bottom=texture_before, label=f'{fmt} Before (Non-Texture)', color=color_before, zorder=2)
         non_texture_after = [max(0, v-t) for v, t in zip(after_vals, texture_after)]
-        bars2 = ax.bar(x + offset + width, non_texture_after, width, label=f'{fmt} After (Non-Texture)', color=color_after, zorder=2)
-        bars2_texture = ax.bar(x + offset + width, texture_after, width, bottom=non_texture_after, label=f'{fmt} After (Texture)', color=color_after_texture, zorder=3)
-        for idx, (bar, v, t) in enumerate(zip(bars1, before_vals, texture_before)):
+        bars2 = ax.bar(x + offset + width, texture_after, width, label=f'{fmt} After (Texture)', color=color_after_texture, zorder=3)
+        bars2_nontex = ax.bar(x + offset + width, non_texture_after, width, bottom=texture_after, label=f'{fmt} After (Non-Texture)', color=color_after, zorder=2)
+        for idx, (bar_tex, bar_nontex, v, t) in enumerate(zip(bars2, bars2_nontex, after_vals, texture_after)):
             if v is None:
-                ax.text(bar.get_x() + bar.get_width()/2., 0.5, 'Missing', ha='center', va='bottom', fontsize=7, color='red', rotation=60, zorder=4)
+                ax.text(bar_tex.get_x() + bar_tex.get_width()/2., 0.5, 'Missing', ha='center', va='bottom', fontsize=7, color='red', rotation=60, zorder=4)
             elif v not in [None, 0]:
-                total_height = non_texture_before[idx] + texture_before[idx]
-                ax.text(bar.get_x() + bar.get_width()/2., total_height, f'{v:.1f}', ha='center', va='bottom', fontsize=7, rotation=60, zorder=4, color='black', fontweight='bold')
+                total_height = texture_after[idx] + non_texture_after[idx]
+                ax.text(bar_tex.get_x() + bar_tex.get_width()/2., total_height, f'{v:.1f}', ha='center', va='bottom', fontsize=7, rotation=60, zorder=4, color='black', fontweight='bold')
                 if t > 0 and v > 0:
                     percent = t / v * 100
                     txt = f'{percent:.0f}%\n{t:.1f}'
                     if t > v * 0.18:
-                        ax.text(bar.get_x() + bar.get_width()/2., bar.get_y() + bar.get_height(), txt, ha='center', va='center', fontsize=7, color='white', zorder=5)
+                        ax.text(bar_tex.get_x() + bar_tex.get_width()/2., bar_tex.get_y() + bar_tex.get_height(), txt, ha='center', va='center', fontsize=7, color='white', zorder=5)
                     else:
-                        ax.plot([bar.get_x() + bar.get_width()/2., bar.get_x() + bar.get_width()/2. + 0.05], [bar.get_y() + bar.get_height(), bar.get_y() + bar.get_height() + max(v*0.08, 2)], color='black', lw=0.7, zorder=6)
-                        ax.text(bar.get_x() + bar.get_width()/2. + 0.08, bar.get_y() + bar.get_height() + max(v*0.08, 2), txt, ha='left', va='bottom', fontsize=7, color='black', zorder=6)
-        for idx, (bar, v, t) in enumerate(zip(bars2, after_vals, texture_after)):
-            if v is None:
-                ax.text(bar.get_x() + bar.get_width()/2., 0.5, 'Missing', ha='center', va='bottom', fontsize=7, color='red', rotation=60, zorder=4)
-            elif v not in [None, 0]:
-                ax.text(bar.get_x() + bar.get_width()/2., bar.get_height(), f'{v:.1f}', ha='center', va='bottom', fontsize=7, rotation=60, zorder=4)
-                if t > 0 and v > 0:
-                    percent = t / v * 100
-                    txt = f'{percent:.0f}%\n{t:.1f}'
-                    if t > v * 0.18:
-                        ax.text(bar.get_x() + bar.get_width()/2., bar.get_y() + bar.get_height(), txt, ha='center', va='center', fontsize=7, color='white', zorder=5)
-                    else:
-                        ax.plot([bar.get_x() + bar.get_width()/2., bar.get_x() + bar.get_width()/2. + 0.05], [bar.get_y() + bar.get_height(), bar.get_y() + bar.get_height() + max(v*0.08, 2)], color='black', lw=0.7, zorder=6)
-                        ax.text(bar.get_x() + bar.get_width()/2. + 0.08, bar.get_y() + bar.get_height() + max(v*0.08, 2), txt, ha='left', va='bottom', fontsize=7, color='black', zorder=6)
+                        ax.plot([bar_tex.get_x() + bar_tex.get_width()/2., bar_tex.get_x() + bar_tex.get_width()/2. + 0.05], [bar_tex.get_y() + bar_tex.get_height(), bar_tex.get_y() + bar_tex.get_height() + max(v*0.08, 2)], color='black', lw=0.7, zorder=6)
+                        ax.text(bar_tex.get_x() + bar_tex.get_width()/2. + 0.08, bar_tex.get_y() + bar_tex.get_height() + max(v*0.08, 2), txt, ha='left', va='bottom', fontsize=7, color='black', zorder=6)
     ax.set_xlabel('Model (Face Count/Texture Count)', fontsize=12)
     ax.set_ylabel('File Size (MB, linear scale)', fontsize=12)
     ax.set_title('Size Before/After Compression Comparison Across Formats (Linear Tall)', fontsize=16, fontweight='bold')
     ax.set_xticks(x)
     labels = [get_standardized_model_name(m, f, t) for m, f, t in zip(models, face_counts, textureCounts)]
     ax.set_xticklabels(labels, rotation=45, ha='right')
-    ax.legend()
+    handles, labels = ax.get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    ax.legend(by_label.values(), by_label.keys())
     ax.grid(True, alpha=0.3, which='both', zorder=1)
     # 强制线性坐标轴
     plt.tight_layout()


### PR DESCRIPTION
Corrected stacked bar segment labels and total value annotation in size comparison charts, and added a linear-scale version for small file visibility.

The 'After' stacked bars now correctly place the 'Texture' component at the bottom and 'Non-Texture' on top, aligning with the user's expectation. The total value annotation is now positioned at the very top of the combined stacked bar. A new chart, "Size Before/After Compression Comparison Across Formats (Linear Tall)", has been introduced with a linear Y-axis and increased height to improve the visibility of smaller file sizes, which were nearly invisible on the logarithmic scale. Legend entries are also merged to avoid duplication.